### PR TITLE
Tweaks for the Rakudo 2024.10 release

### DIFF
--- a/lib/Menu/Simple.rakumod
+++ b/lib/Menu/Simple.rakumod
@@ -193,9 +193,9 @@ class Menu does Option-group is export {
 
     method validate-selection(--> Bool) {
         self.validated-selection = Nil;
-        my $valid = False;
-        try { $valid = self.selection >= self.options.keys.sort.first && !(self.selection > self.option-count) };
-        return $valid;
+        (try self.selection >= self.options.keys.sort.first
+          && !(self.selection > self.option-count)
+        ) // False
     }
 
     method process-selection() {

--- a/t/00-sanity.rakutest
+++ b/t/00-sanity.rakutest
@@ -16,7 +16,7 @@ sub some-sub {
     say 'done!';
 }
 
-sub check-process($menu, $value, $expected) {
+sub check-process($menu, $value, $expected) is test-assertion {
     $menu.selection = $value;
     is $menu.validate-selection, $expected, 'validates or invalidates selection';
 }


### PR DESCRIPTION
Make sanity check less fragile
    
Fixes in numeric infix ops produce Failures in some combinations instead of throwing exceptions.  They were always intended to just return Failures if something went wrong.
    
Simplify the validation check to handle this.

Also mark sub as test-assertion so that error reporting points at what is being tested, rather than how it was being tested.